### PR TITLE
feat: enable wildcard search

### DIFF
--- a/backend/lib/routes/search.ts
+++ b/backend/lib/routes/search.ts
@@ -19,7 +19,7 @@ export const getVersionRange = (versions: string[], wantedVersion: string) => {
 const findBlob = async (req: Request, res: Response, next: NextFunction) => {
   const {searchTerm, searchVersion} = req.body
   const nameSearch = await Blob.find({
-    name: searchTerm,
+    name: { $regex: searchTerm, $options: "i" },
   })
   const tagSearch = await Blob.find({
     tags: searchTerm,


### PR DESCRIPTION
Hi @hweeks, thanks for creating and sharing this project! It looks very interesting and I'd love to add a few things.

This patch changes the Mongoose search query to enable a wildcard search on the package name, as the search currently only matches the whole package name.  